### PR TITLE
Fix code block formatting issue when publishing to WeChat

### DIFF
--- a/src/assets/default-styles/25_code.css
+++ b/src/assets/default-styles/25_code.css
@@ -1,7 +1,8 @@
 /* code section */
 
 :root {
-	--code-container-background-color: #282c34; /*#1E1E1E;*/
+	--code-container-background-color: #282c34;
+	/*#1E1E1E;*/
 	--code-section-background-color: #282c34;
 	--code-color: #abb2bf;
 	--code-comment-color: #5c6370;
@@ -76,7 +77,9 @@
 	padding: 10px 5px !important;
 	padding-left: .5em;
 	font-family: Consolas, Monaco, Menlo, monospace;
-	text-wrap: nowrap;
+	white-space: pre-wrap !important;
+	word-wrap: break-word !important;
+	overflow-x: auto;
 }
 
 .wewrite .code-section ul {
@@ -84,7 +87,7 @@
 	padding-bottom: var(--code-padding, 8px);
 	position: relative;
 	overflow: hidden;
-	background: var(--code-section-background-color, #282c34)!important;
+	background: var(--code-section-background-color, #282c34) !important;
 	display: flex;
 	flex-direction: column;
 	flex-shrink: 0;
@@ -94,7 +97,7 @@
 	white-space: normal;
 	width: fit-content;
 	user-select: none;
-	border-right: solid 0.5px  rgb(166, 166, 166);
+	border-right: solid 0.5px rgb(166, 166, 166);
 	padding-right: 5px;
 	color: var(--code-line-color, green);
 	border-bottom-left-radius: var(--code-border-radius, 4px);
@@ -112,7 +115,7 @@
 	list-style-type: none;
 	color: var(--code-line-color, red);
 	padding-left: 1rem;
-	
+
 }
 
 .wewrite .code-section ul>li::marker {

--- a/src/render/marked-extensions/code.ts
+++ b/src/render/marked-extensions/code.ts
@@ -41,14 +41,19 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 
 	codeRenderer(code: string, infostring: string | undefined): string {
 		const lang = (infostring || '').match(/^\S*/)?.[0];
-		code = code.replace(/\n$/, '') + '\n';
+		// 保留原始代码格式，将空格和制表符转换为HTML实体
+		const originalCode = code;
+		code = code
+			.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;') // 制表符转为4个不间断空格
+			.replace(/ /g, '&nbsp;') // 普通空格转为不间断空格
+			.replace(/\n/g, '<br>'); // 换行符转为br标签
 
 		let codeSection = '<section class="code-container"><section class="code-section-banner"></section><section class="code-section">';
 
 		const codeLineNumber = this.previewRender.articleProperties.get('show-code-line-number')
 
 		if (codeLineNumber === 'true' || codeLineNumber === 'yes' || codeLineNumber === '1') {
-			const lines = code.split('\n');
+			const lines = originalCode.split('\n');
 
 			let liItems = '';
 			let count = 1;
@@ -59,11 +64,9 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 			codeSection += `<ul>${liItems}</ul>`;
 		}
 
-
 		if (!lang) {
 			codeSection += `<pre><code>${code}</code></pre>`;
 		} else {
-
 			codeSection += `<pre><code class="hljs language-${lang}" >${code}</code></pre>`
 		}
 
@@ -137,7 +140,7 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 		this.mermaidIndex++;
 
 		const renderer = ObsidianMarkdownRenderer.getInstance(this.plugin.app);
-		
+
 		const root = renderer.queryElement(index, '.mermaid')
 		if (!root) {
 			return
@@ -248,7 +251,7 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 
 					token.html = await this.renderAdmonitionAsync(token, type);
 				}
-				
+
 			}
 		}
 	}

--- a/themes/13. 罗老师代码修复版.md
+++ b/themes/13. 罗老师代码修复版.md
@@ -1,0 +1,186 @@
+---
+author: 罗老师 & Claude
+theme_name: 罗老师代码修复版
+---
+
+> [!note]
+> 这个主题专门解决WeWrite插件中代码块格式错乱的问题
+> 基于爱范儿主题风格，增强了代码块的显示效果
+
+## 1. 全局变量
+
+```CSS
+:root {
+  --article-font-family: "PingFang SC", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Tahoma, Arial, "Heiti SC", STHeiti, SimHei, sans-serif; 
+  --article-line-height: 27px;
+  --article-font-weight: 300;
+  --paragraph-font-family: PingFangSC-light, system-ui;
+  --article-text-font-size: 15px;
+  --article-text-color: rgb(34, 34, 34);
+  --paragraph-margin: 27px 0;
+  --paragraph-padding: 0 15px;
+  --image-caption-text-color: #A7A7A7;
+  --image-cation-font-size: 12px;
+  --heading-color: #66CDAA;
+  --heading-font-family: PingFangSC-Semibold, system-ui;
+  --heading-font-weight: 600;
+  --strong-color: #FD4606;
+  --article-max-width: none;
+  --heading-margin: 1rem 0;
+  --article-text-align: justify;
+  --article-font-size: 15px;
+}
+```
+
+## 2. 代码块样式修复（核心功能）
+
+```CSS
+/* 代码块容器样式 */
+.wewrite .code-container {
+  display: flex;
+  flex-direction: column;
+  border-radius: 6px;
+  background: #f6f8fa;
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 8px;
+  border: 1px solid #e1e4e8;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+
+/* 代码区域样式 */
+.wewrite .code-section {
+  display: flex;
+  flex-grow: 1;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+/* 关键！代码文本样式 - 解决格式问题 */
+.wewrite .code-section pre {
+  position: relative;
+  padding: 16px;
+  margin: 0;
+  flex: 1;
+  overflow: auto;
+  background: #f6f8fa;
+  /* 关键属性：保留所有空格、制表符和换行 */
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+}
+
+.wewrite .code-section code {
+  display: block;
+  padding: 0 !important;
+  /* 使用等宽字体确保对齐 */
+  font-family: 'Courier New', Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+  font-size: 14px !important;
+  /* 关键属性：保留空格格式 */
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  /* 移除默认边框和背景 */
+  border: none !important;
+  background: transparent !important;
+}
+
+/* 语法高亮颜色 */
+.wewrite .hljs {
+  color: #24292e;
+  background: transparent;
+}
+
+.wewrite .hljs-comment,
+.wewrite .hljs-quote {
+  color: #6a737d;
+  font-style: italic;
+}
+
+.wewrite .hljs-keyword,
+.wewrite .hljs-selector-tag,
+.wewrite .hljs-literal,
+.wewrite .hljs-section,
+.wewrite .hljs-link {
+  color: #d73a49;
+}
+
+.wewrite .hljs-string {
+  color: #032f62;
+}
+
+.wewrite .hljs-title,
+.wewrite .hljs-name,
+.wewrite .hljs-type,
+.wewrite .hljs-attribute {
+  color: #6f42c1;
+}
+
+.wewrite .hljs-number,
+.wewrite .hljs-symbol,
+.wewrite .hljs-bullet {
+  color: #005cc5;
+}
+
+.wewrite .hljs-built_in,
+.wewrite .hljs-builtin-name {
+  color: #e36209;
+}
+```
+
+## 3. 标题样式
+
+```CSS
+h1 .wewrite-heading-outbox {
+  margin: 0 auto;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+}
+
+:root {
+  --heading-color: rgb(0, 128, 255);
+  --h2-font-size: 21px;
+  --blockquote-font-style: normal;
+}
+
+.wewrite {
+  font-family: var(--article-font-family);
+  font-weight: var(--article-font-weight);
+  word-break: var(--article-word-break);
+  letter-spacing: var(--article-letter-space);
+  color: var(--article-text-color);
+  font-size: var(--article-text-font-size);
+  line-height: var(--article-line-height);
+  text-align: var(--article-text-align);
+  text-indent: var(--article-text-indent);
+  font-style: var(--article-font-style); 
+}
+```
+
+## 4. 引用样式
+
+```CSS
+blockquote {
+  position: relative;
+  display: inline-block;
+  padding: 0 15px;
+  border-left: 4px solid #d8d8d8;
+  line-height: 23px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #222222;
+  background: transparent;
+  border-radius: 0px;
+}
+
+.wewrite-image-caption {
+  font-size: 12px;
+  color: rgb(136, 136, 136)
+}
+```
+
+## 5. 强调文本样式
+
+```CSS
+strong {
+  color: var(--strong-color);
+  font-weight: 600;
+}
+```


### PR DESCRIPTION
- Convert spaces and tabs to non-breaking HTML entities
- Update CSS to use white-space: pre-wrap for better formatting
- Add custom theme with enhanced code block styling
- Resolves code structure loss in WeChat MP editor


## 🐛 问题描述
代码块在发布到微信公众号时，缩进和层级关系丢失，导致代码格式错乱，影响阅读体验。

## 🔧 解决方案
1. **修改代码渲染逻辑** (`src/render/marked-extensions/code.ts`)
   - 将普通空格转换为HTML不间断空格 (`&nbsp;`)
   - 将制表符转换为4个不间断空格
   - 将换行符转换为 `<br>` 标签

2. **优化CSS样式** (`src/assets/default-styles/25_code.css`)
   - 使用 `white-space: pre-wrap` 保持代码格式
   - 添加 `word-wrap: break-word` 处理长行

3. **新增主题文件** (`themes/13. 罗老师代码修复版.md`)
   - 提供完整的代码块样式解决方案
   - 基于爱范儿风格的美化主题

## ✅ 测试验证
- [x] 本地编译通过
- [x] 代码格式在微信公众号中正确显示
- [x] 保持了原有功能的完整性

## 📸 效果说明
修复后的代码块能够完美保持缩进层级，解决了微信公众号编辑器清理格式的问题。

## 🙏 贡献说明
这是我第一次为开源项目贡献代码，希望能帮助到所有使用WeWrite的用户。