### PR TITLE
修复blockquote内联元素解析和链接去重问题

### DIFF
--- a/src/render/marked-extensions/blockquote.ts
+++ b/src/render/marked-extensions/blockquote.ts
@@ -22,8 +22,10 @@ export class BlockquoteRenderer extends WeWriteMarkedExtension {
     return;
   }
 
-  rendererBlockquote(token: Tokens.Blockquote) {
-    const text = token.text.replace(/\n/gm, '<br>').trim()
+  async rendererBlockquote(token: Tokens.Blockquote) {
+    // 使用marked来解析blockquote中的内联元素，如链接
+    const parsedText = await this.marked.parseInline(token.text);
+    const text = parsedText.replace(/\n/gm, '<br>').trim();
     return `<blockquote dir="auto" ><span class="icon-pin"></span><div class="blockquote-inner" >${text}</div></blockquote>`
   }
   async rendererCallout(_token: Tokens.Blockquote) {
@@ -65,7 +67,7 @@ export class BlockquoteRenderer extends WeWriteMarkedExtension {
         if (matched){
           token.html =  await this.rendererCallout(token as Tokens.Blockquote)
         }else{
-          token.html =  this.rendererBlockquote(token as Tokens.Blockquote);
+          token.html =  await this.rendererBlockquote(token as Tokens.Blockquote);
         }
       },
       extensions: [{

--- a/src/render/marked-extensions/links.ts
+++ b/src/render/marked-extensions/links.ts
@@ -19,10 +19,12 @@ export class Links extends WeWriteMarkedExtension {
         if (!this.allLinks.length) {
             return html;
         }
-        const links = this.allLinks.map((href, i) => {
+        // 去重但保持顺序
+        const uniqueLinks = [...new Set(this.allLinks)];
+        const links = uniqueLinks.map((href, i) => {
             return `<li>${href}&nbsp;↩</li>`;
         });
-        return `${html}<seciton class="foot-links"><br><hr class="foot-links-separator"><ol>${links.join('')}</ol></section>`;
+        return `${html}<section class="foot-links"><hr class="foot-links-separator"><ol>${links.join('')}</ol></section>`;
     }
 
     markedExtension(): MarkedExtension {
@@ -31,14 +33,13 @@ export class Links extends WeWriteMarkedExtension {
                 name: 'link',
                 level: 'inline',
                 renderer: (token: Tokens.Link) => {
-                    if (token.text.indexOf(token.href) === 0
-                        || (token.href.indexOf('https://mp.weixin.qq.com/mp') === 0)
-                        || (token.href.indexOf('https://mp.weixin.qq.com/s') === 0) 
-                        ) {
+                    if (token.href.startsWith('http')) {
+                        this.allLinks.push(token.href);
+                        return `<a href="${token.href}">${token.text}<sup>[${this.allLinks.length}]</sup></a>`;
+                    } else {
+                        // 非http外链直接返回，不添加到foot-links中
                         return `<a href="${token.href}">${token.text}</a>`;
                     }
-                    this.allLinks.push(token.href);
-                    return `<a>${token.text}<sup>[${this.allLinks.length}]</sup></a>`;
                     // else {
                     //     return `<a>${token.text}[${token.href}]</a>`;
                     // }


### PR DESCRIPTION
fix(render): 修复blockquote内联元素解析和链接去重问题

修复blockquote中内联元素（如链接）未正确解析的问题，改为使用marked解析。
同时优化链接处理逻辑，去除重复链接但保持顺序，并过滤非http开头的链接。