### PR TITLE
修复自用过程中发现的一系列问题

### DIFF
--- a/src/lang/locales/en-us.json
+++ b/src/lang/locales/en-us.json
@@ -178,7 +178,8 @@
       "only-fans-can-comment-description": "Everyone can comment by default.",
       "open-comments": "Open comments",
       "testing-button": "Testing button",
-      "title": "Draft header"
+      "title": "Draft header",
+      "upload-cover-image-error": "Failed to upload cover image"
     },
     "delete-draft": "Delete draft",
     "delete-image": "Delete image",
@@ -210,8 +211,10 @@
       "send-article-to-draft-box": "Send article to draft box",
       "testing-button": "Testing button",
       "to-verify-the-images-in-article": "Verify images in the article",
-      "wewrite-previewer": "WeWrite previewer"
-    },
+      "wewrite-previewer": "WeWrite previewer",
+      "convert-links-to-strong-tags": "Convert links to strong tags",
+      "links-converted-to-strong-tags-successfully": "Links converted to strong tags successfully"
+     },
     "send-mass-message": "Send mass message",
     "theme-manager": {
       "default-theme": "Default theme",

--- a/src/lang/locales/zh-cn.json
+++ b/src/lang/locales/zh-cn.json
@@ -178,7 +178,8 @@
       "only-fans-can-comment-description": "默认所有人都可评论",
       "open-comments": "开启评论",
       "testing-button": "测试按钮",
-      "title": "文章属性"
+      "title": "文章属性",
+      "upload-cover-image-error": "上传封面图片失败"
     },
     "delete-draft": "删除草稿",
     "delete-image": "删除图片",
@@ -210,8 +211,10 @@
       "send-article-to-draft-box": "发送文章到草稿箱",
       "testing-button": "测试按钮",
       "to-verify-the-images-in-article": "验证文章中的图片",
-      "wewrite-previewer": "WeWrite预览器"
-    },
+      "wewrite-previewer": "WeWrite预览器",
+      "convert-links-to-strong-tags": "将链接转换为粗体标签",
+      "links-converted-to-strong-tags-successfully": "链接已成功转换为粗体标签"
+     },
     "send-mass-message": "群发消息",
     "theme-manager": {
       "default-theme": "默认主题",

--- a/src/render/marked-extensions/code.ts
+++ b/src/render/marked-extensions/code.ts
@@ -41,19 +41,14 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 
 	codeRenderer(code: string, infostring: string | undefined): string {
 		const lang = (infostring || '').match(/^\S*/)?.[0];
-		// 保留原始代码格式，将空格和制表符转换为HTML实体
-		const originalCode = code;
-		code = code
-			.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;') // 制表符转为4个不间断空格
-			.replace(/ /g, '&nbsp;') // 普通空格转为不间断空格
-			.replace(/\n/g, '<br>'); // 换行符转为br标签
+		code = code.replace(/\n$/, '') + '\n';
 
 		let codeSection = '<section class="code-container"><section class="code-section-banner"></section><section class="code-section">';
 
 		const codeLineNumber = this.previewRender.articleProperties.get('show-code-line-number')
 
 		if (codeLineNumber === 'true' || codeLineNumber === 'yes' || codeLineNumber === '1') {
-			const lines = originalCode.split('\n');
+			const lines = code.split('\n');
 
 			let liItems = '';
 			let count = 1;
@@ -64,9 +59,11 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 			codeSection += `<ul>${liItems}</ul>`;
 		}
 
+
 		if (!lang) {
 			codeSection += `<pre><code>${code}</code></pre>`;
 		} else {
+
 			codeSection += `<pre><code class="hljs language-${lang}" >${code}</code></pre>`
 		}
 
@@ -140,7 +137,7 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 		this.mermaidIndex++;
 
 		const renderer = ObsidianMarkdownRenderer.getInstance(this.plugin.app);
-
+		
 		const root = renderer.queryElement(index, '.mermaid')
 		if (!root) {
 			return
@@ -251,7 +248,7 @@ export class CodeRenderer extends WeWriteMarkedExtension {
 
 					token.html = await this.renderAdmonitionAsync(token, type);
 				}
-
+				
 			}
 		}
 	}

--- a/src/render/marked-extensions/footnote.ts
+++ b/src/render/marked-extensions/footnote.ts
@@ -34,7 +34,7 @@ export class Footnote extends WeWriteMarkedExtension {
                     },
                     renderer: (token) => {
                         if (token.type === 'footnote') {
-                            return `<div id="footnote-${token.id}" class="footnote"><span class="footnote-id">【${token.id}】 </span>${token.text}</div>`;
+                            return `<div id="footnote-${token.id}" class="footnote"><span class="footnote-id">【${token.id}】 </span>${token.text?token.text:''}</div>`;
                         }
                     }
                 },
@@ -59,7 +59,7 @@ export class Footnote extends WeWriteMarkedExtension {
                     },
                     renderer: (token) => {
                         if (token.type === 'footnoteMark') {
-                            return `<a>${token.text}<sup>【${token.id}】</sup></a>`
+                            return `<a>${token.text?token.text:''}<sup>【${token.id}】</sup></a>`
                         }
                     }
                 }

--- a/src/render/marked-extensions/link-to-strong.ts
+++ b/src/render/marked-extensions/link-to-strong.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility functions to convert all a tags to strong tags
+ * This can be used in UI to replace links with strong tags on demand
+ */
+
+export class LinkToStrong {
+    /**
+     * Replaces all <a> tags with <strong> tags while preserving the content and styles
+     * @param html The HTML string containing a tags to be replaced
+     * @returns HTML string with a tags replaced by strong tags, preserving styles
+     */
+    static convertATagsToStrongTags(html: string): string {
+        // Replace all <a> tags with <strong> tags while preserving attributes (especially style attributes)
+        // This regex captures the attributes from the opening <a> tag and transfers them to the <strong> tag
+        return html.replace(/<a([^>]*)>(.*?)<\/a>/g, (match, attributes, content) => {
+            // We only want to preserve certain attributes like style, class, etc.
+            // Filter out href and other link-specific attributes
+            const preservedAttributes = attributes
+                .replace(/\s*href\s*=\s*["'][^"']*["']/gi, '') // Remove href attribute
+                .replace(/\s*target\s*=\s*["'][^"']*["']/gi, '') // Remove target attribute
+                .replace(/\s*rel\s*=\s*["'][^"']*["']/gi, '') // Remove rel attribute
+                .trim();
+            
+            if (preservedAttributes) {
+                return `<strong ${preservedAttributes}>${content}</strong>`;
+            } else {
+                return `<strong>${content}</strong>`;
+            }
+        });
+    }
+}

--- a/src/render/post-render.ts
+++ b/src/render/post-render.ts
@@ -7,6 +7,7 @@ import { fetchImageBlob } from 'src/utils/utils';
 import { WechatClient } from './../wechat-api/wechat-client';
 import WeWritePlugin from 'src/main';
 import { log } from 'console';
+import { validateAndConvertImage } from 'src/utils/image-utils';
 function imageFileName(mime:string){
     const type = mime.split('/')[1]
     return `image-${new Date().getTime()}.${type}`
@@ -82,7 +83,9 @@ export async function uploadSVGs(root: HTMLElement, wechatClient: WechatClient){
             return
         }
         await svgToPng(svgString).then(async blob => {
-            await wechatClient.uploadMaterial(blob, imageFileName(blob.type)).then(res => {
+            // 验证并转换图片格式
+            const validatedBlob = await validateAndConvertImage(blob);
+            await wechatClient.uploadMaterial(validatedBlob, imageFileName(validatedBlob.type)).then(res => {
                 if (res){
                     svg.outerHTML = `<img src="${res.url}" />`
                 }else{
@@ -103,7 +106,9 @@ export async function uploadCanvas(root:HTMLElement, wechatClient:WechatClient):
     
     const uploadPromises = canvases.map(async (canvas) => {
         const blob = getCanvasBlob(canvas);
-        await wechatClient.uploadMaterial(blob, imageFileName(blob.type)).then(res => {
+        // 验证并转换图片格式
+        const validatedBlob = await validateAndConvertImage(blob);
+        await wechatClient.uploadMaterial(validatedBlob, imageFileName(validatedBlob.type)).then(res => {
             if (res){
                 canvas.outerHTML = `<img src="${res.url}" />`
             }else{
@@ -147,8 +152,9 @@ export async function uploadURLImage(root:HTMLElement, wechatClient:WechatClient
             return
             
         }else{
-
-            await wechatClient.uploadMaterial(blob, imageFileName(blob.type)).then(res => {
+            // 验证并转换图片格式
+            const validatedBlob = await validateAndConvertImage(blob);
+            await wechatClient.uploadMaterial(validatedBlob, imageFileName(validatedBlob.type)).then(res => {
                 if (res){
                     img.src = res.url
                 }else{
@@ -231,10 +237,11 @@ export async function uploadURLVideo(root:HTMLElement, wechatClient:WechatClient
             
         }else{
 			
+            // 注意：视频文件不进行图片格式转换
             await wechatClient.uploadMaterial(blob, imageFileName(blob.type), 'video').then(async res => {
                 if (res){
-					const video_info = await wechatClient.getMaterialById(res.media_id)
-					video.src = video_info.url
+                    const video_info = await wechatClient.getMaterialById(res.media_id)
+                    video.src = video_info.url
                 }else{
                     console.error(`upload video failed.`);
                     

--- a/src/utils/ai-client.ts
+++ b/src/utils/ai-client.ts
@@ -39,10 +39,19 @@ export class AiClient {
 			throw new Error($t("utils.no-ai-server-url-given"));
 		}
 		
-		if (account.baseUrl.startsWith("https://")) {
-			return this.openaiClient
-		} else {
+		// 根据API路径特点判断是Ollama还是OpenAI服务
+		// Ollama API路径通常包含 /api/chat，OpenAI API路径通常包含 /v1/chat/completions
+		if (account.baseUrl.includes("/api/chat")) {
 			return this.ollamaClient;
+		} else if (account.baseUrl.includes("/v1")) {
+			return this.openaiClient;
+		} else {
+			// 默认情况下，如果包含11434端口则认为是Ollama
+			if (account.baseUrl.includes(":11434")) {
+				return this.ollamaClient;
+			} else {
+				return this.openaiClient;
+			}
 		}
 	}
 	public async getModelList(account:string|undefined = undefined): Promise<string[]> {

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -1,0 +1,111 @@
+/**
+ * 图片格式验证和转换工具
+ */
+
+/**
+ * 检查图片格式是否被支持
+ * @param mimeType MIME类型，如 'image/jpeg', 'image/png' 等
+ * @returns 如果格式被支持返回 true，否则返回 false
+ */
+export function isSupportedImageFormat(mimeType: string): boolean {
+    const supportedFormats = [
+        'image/jpeg',
+        'image/jpg', 
+        'image/png',
+        'image/gif',
+        'image/webp'
+    ];
+    return supportedFormats.includes(mimeType.toLowerCase());
+}
+
+/**
+ * 将不支持的图片格式转换为JPEG格式
+ * @param blob 原始图片Blob
+ * @returns 转换后的JPEG格式Blob
+ */
+export async function convertToJpeg(blob: Blob): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+        // 如果已经是JPEG格式，直接返回
+        if (blob.type === 'image/jpeg' || blob.type === 'image/jpg') {
+            resolve(blob);
+            return;
+        }
+
+        const img = new Image();
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+            reject(new Error('无法获取canvas上下文'));
+            return;
+        }
+
+        img.onload = () => {
+            try {
+                // 设置canvas尺寸为图片尺寸
+                canvas.width = img.width;
+                canvas.height = img.height;
+
+                // 将图片绘制到canvas上
+                ctx.drawImage(img, 0, 0);
+
+                // 转换为JPEG格式的blob
+                canvas.toBlob(
+                    (jpegBlob) => {
+                        if (jpegBlob) {
+                            resolve(jpegBlob);
+                        } else {
+                            reject(new Error('转换为JPEG格式失败'));
+                        }
+                    },
+                    'image/jpeg',
+                    0.9 // JPEG质量
+                );
+            } catch (error) {
+                reject(error);
+            }
+        };
+
+        img.onerror = (error) => {
+            reject(error);
+        };
+
+        // 创建图片URL并加载
+        img.src = URL.createObjectURL(blob);
+    });
+}
+
+/**
+ * 验证并转换图片格式
+ * @param blob 图片Blob
+ * @returns 验证并转换后的Blob，如果是不支持的格式则转换为JPEG
+ */
+export async function validateAndConvertImage(blob: Blob): Promise<Blob> {
+    if (isSupportedImageFormat(blob.type)) {
+        return blob;
+    }
+
+    // 如果格式不支持，则转换为JPEG
+    return await convertToJpeg(blob);
+}
+
+/**
+ * 从文件名获取MIME类型
+ * @param filename 文件名
+ * @returns MIME类型
+ */
+export function getMimeTypeFromFilename(filename: string): string {
+    const extension = filename.toLowerCase().split('.').pop() || '';
+    const mimeTypes: { [key: string]: string } = {
+        'jpg': 'image/jpeg',
+        'jpeg': 'image/jpeg',
+        'png': 'image/png',
+        'gif': 'image/gif',
+        'webp': 'image/webp',
+        'bmp': 'image/bmp',
+        'tiff': 'image/tiff',
+        'svg': 'image/svg+xml'
+    };
+
+    return mimeTypes[extension] || 'application/octet-stream';
+}

--- a/src/utils/openAI-client.ts
+++ b/src/utils/openAI-client.ts
@@ -56,8 +56,6 @@ export class OpenAIClient {
 		const completion = await openai.chat.completions.create({
 			model: account.model || "qwen-plus", //"deepseek-chat",
 			messages: msg as ChatCompletionMessage[],
-			max_tokens: 100,
-			temperature: 0.7,
 		});
 		return completion.choices[0].message.content;
 	}

--- a/src/views/mp-article-header.ts
+++ b/src/views/mp-article-header.ts
@@ -19,6 +19,7 @@ import { ImageGenerateModal } from "../modals/image-generate-modal";
 import { ResourceManager } from "src/assets/resource-manager";
 
 import { $t } from "src/lang/i18n";
+import { validateAndConvertImage } from "src/utils/image-utils";
 
 export class MPArticleHeader {
 	updateDraftDraftId(media_id: any) {
@@ -397,8 +398,10 @@ export class MPArticleHeader {
 				return;
 			}
 
+			// 验证并转换图片格式
+			const validatedBlob = await validateAndConvertImage(blob);
 			const res = await WechatClient.getInstance(this.plugin).uploadMaterial(
-				blob,
+				validatedBlob,
 				"banner-cover.png",
 				"image"
 			);

--- a/src/views/previewer.ts
+++ b/src/views/previewer.ts
@@ -20,6 +20,7 @@ import {
 import { $t } from "src/lang/i18n";
 import WeWritePlugin from "src/main";
 import { PreviewRender } from "src/render/marked-extensions/extension";
+import { LinkToStrong } from "src/render/marked-extensions/link-to-strong";
 import {
 	uploadCanvas,
 	uploadSVGs,
@@ -227,7 +228,24 @@ export class PreviewPanel extends ItemView implements PreviewRender {
 							$t("views.previewer.article-copied-to-clipboard")
 						);
 					});
-			});
+			})
+			.addExtraButton((button) => {
+				button
+					.setIcon("bold")
+					.setTooltip($t("views.previewer.convert-links-to-strong-tags"))
+					.onClick(async () => {
+						await this.convertLinksToStrongTags();
+					});
+			})
+			// 调试时打开注释
+			// .addExtraButton((button) => {
+			// 	button
+			// 		.setIcon("view")
+			// 		.setTooltip("查看草稿数据")
+			// 		.onClick(async () => {
+			// 			this.showDraftData();
+			// 		});
+			// });
 
 		this.draftHeader = new MPArticleHeader(this.plugin, mainDiv);
 
@@ -284,8 +302,44 @@ export class PreviewPanel extends ItemView implements PreviewRender {
 			}
 		}
 	}
+	/**
+	 * Compress HTML by removing unnecessary whitespace while preserving content in pre, code, and textarea tags
+	 */
+	private compressHTML(html: string): string {
+		// Store protected elements temporarily
+		const protectedElements: string[] = [];
+		
+		// Extract and store pre, code, textarea elements, with content escaping
+		html = html.replace(/<(pre|code|textarea)([^>]*?)>([\s\S]*?)<\/\1>/gi, (match, tag, attrs, content) => {
+			// Escape content for protected elements: tab to 4 non-breaking spaces, space to non-breaking space, newline to <br>
+			const escapedContent = content
+				.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;') // 制表符转为4个不间断空格
+				.replace(/\n/g, '<br>'); // 换行符转为br标签
+			
+			const escapedElement = `<${tag}${attrs}>${escapedContent}</${tag}>`;
+			protectedElements.push(escapedElement);
+			return `<!--PROTECTED_ELEMENT_${protectedElements.length - 1}-->`;
+		});
+		
+		// Compress the remaining HTML (outside protected elements)
+		html = html
+			// Replace multiple whitespaces with single space
+			.replace(/\s+/g, ' ')
+			// Remove whitespaces around HTML tags
+			.replace(/\s*(<[^>]+>)\s*/g, '$1')
+			// Trim the entire string
+			.trim();
+		
+		// Restore protected elements
+		html = html.replace(/<!--PROTECTED_ELEMENT_(\d+)-->/g, (match, index) => {
+			return protectedElements[parseInt(index)];
+		});
+		
+		return html;
+	}
+
 	public getArticleContent() {
-		return this.articleDiv.innerHTML;
+		return this.compressHTML(this.articleDiv.innerHTML);
 	}
 	// async getCSS() {
 	// 	return await ThemeManager.getInstance(this.plugin).getCSS();
@@ -296,6 +350,150 @@ export class PreviewPanel extends ItemView implements PreviewRender {
 		this.stopListen();
 	}
 
+	/**
+	 * Converts all <a> tags to <strong> tags in the rendered article content, preserving styles
+	 */
+	async convertLinksToStrongTags() {
+		const currentContent = this.articleDiv.innerHTML;
+		const updatedContent = LinkToStrong.convertATagsToStrongTags(currentContent);
+		this.articleDiv.innerHTML = updatedContent;
+		new Notice($t("views.previewer.links-converted-to-strong-tags-successfully"));
+	}
+
+	private async showDraftData() {
+		// 获取两个方法的值
+		const draftData = this.draftHeader.getActiveLocalDraft();
+		const articleContent = this.getArticleContent();
+		
+		// 安全的字符串化函数，处理循环引用
+		const safeStringify = (obj: any): string => {
+			const seen = new WeakSet();
+			return JSON.stringify(obj, (key, val) => {
+				if (val != null && typeof val === "object") {
+					if (seen.has(val)) return "[Circular]";
+					seen.add(val);
+				}
+				return val;
+			}, 2);
+		};
+		
+		// 创建弹窗显示内容
+		const modalContent = `
+			<h3>草稿数据</h3>
+			<div style="margin-bottom: 20px;">
+				<h4>Active Local Draft:</h4>
+				<pre style="background: #f5f5f5; padding: 10px; border-radius: 4px; overflow: auto; max-height: 200px; white-space: pre-wrap; word-wrap: break-word;">${safeStringify(draftData)}</pre>
+			</div>
+			<div style="margin-bottom: 20px;">
+				<h4>Article Content:</h4>
+				<pre style="background: #f5f5f5; padding: 10px; border-radius: 4px; overflow: auto; max-height: 200px; white-space: pre-wrap; word-wrap: break-word;">${articleContent}</pre>
+			</div>
+		`;
+		
+		// 创建自定义模态框
+		const modal = document.createElement('div');
+		modal.className = 'modal-container';
+		modal.style.position = 'fixed';
+		modal.style.top = '0';
+		modal.style.left = '0';
+		modal.style.width = '100%';
+		modal.style.height = '100%';
+		modal.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
+		modal.style.display = 'flex';
+		modal.style.justifyContent = 'center';
+		modal.style.alignItems = 'center';
+		modal.style.zIndex = '9999';
+		modal.style.fontFamily = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+		
+		const modalContentDiv = document.createElement('div');
+		modalContentDiv.className = 'modal-content';
+		modalContentDiv.style.backgroundColor = 'white';
+		modalContentDiv.style.padding = '20px';
+		modalContentDiv.style.borderRadius = '8px';
+		modalContentDiv.style.maxWidth = '80%';
+		modalContentDiv.style.maxHeight = '80%';
+		modalContentDiv.style.overflow = 'auto';
+		modalContentDiv.innerHTML = modalContent;
+		
+		// 添加复制按钮
+		const copyButton = document.createElement('button');
+		copyButton.textContent = '复制所有数据';
+		copyButton.style.marginTop = '10px';
+		copyButton.style.padding = '8px 16px';
+		copyButton.style.backgroundColor = '#007acc';
+		copyButton.style.color = 'white';
+		copyButton.style.border = 'none';
+		copyButton.style.borderRadius = '4px';
+		copyButton.style.cursor = 'pointer';
+		copyButton.style.marginRight = '10px';
+		
+		copyButton.onclick = async () => {
+			const fullData = `草稿数据:\n${safeStringify(draftData)}\n\n文章内容:\n${articleContent}`;
+			await navigator.clipboard.writeText(fullData);
+			new Notice('数据已复制到剪贴板');
+		};
+		
+		modalContentDiv.appendChild(copyButton);
+		
+		// 添加复制草稿数据按钮
+		const copyDraftButton = document.createElement('button');
+		copyDraftButton.textContent = '仅复制草稿数据';
+		copyDraftButton.style.marginTop = '10px';
+		copyDraftButton.style.padding = '8px 16px';
+		copyDraftButton.style.backgroundColor = '#28a745';
+		copyDraftButton.style.color = 'white';
+		copyDraftButton.style.border = 'none';
+		copyDraftButton.style.borderRadius = '4px';
+		copyDraftButton.style.cursor = 'pointer';
+		copyDraftButton.style.marginRight = '10px';
+		
+		copyDraftButton.onclick = async () => {
+			const draftDataStr = safeStringify(draftData);
+			await navigator.clipboard.writeText(draftDataStr);
+			new Notice('草稿数据已复制到剪贴板');
+		};
+		
+		modalContentDiv.appendChild(copyDraftButton);
+		
+		// 添加复制文章内容按钮
+		const copyContentButton = document.createElement('button');
+		copyContentButton.textContent = '仅复制文章内容';
+		copyContentButton.style.marginTop = '10px';
+		copyContentButton.style.padding = '8px 16px';
+		copyContentButton.style.backgroundColor = '#17a2b8';
+		copyContentButton.style.color = 'white';
+		copyContentButton.style.border = 'none';
+		copyContentButton.style.borderRadius = '4px';
+		copyContentButton.style.cursor = 'pointer';
+		copyContentButton.style.marginRight = '10px';
+		
+		copyContentButton.onclick = async () => {
+			await navigator.clipboard.writeText(articleContent);
+			new Notice('文章内容已复制到剪贴板');
+		};
+		
+		modalContentDiv.appendChild(copyContentButton);
+		
+		// 添加关闭按钮
+		const closeButton = document.createElement('button');
+		closeButton.textContent = '关闭';
+		closeButton.style.marginTop = '10px';
+		closeButton.style.padding = '8px 16px';
+		closeButton.style.backgroundColor = '#6c757d';
+		closeButton.style.color = 'white';
+		closeButton.style.border = 'none';
+		closeButton.style.borderRadius = '4px';
+		closeButton.style.cursor = 'pointer';
+		
+		closeButton.onclick = () => {
+			document.body.removeChild(modal);
+		};
+		
+		modalContentDiv.appendChild(closeButton);
+		modal.appendChild(modalContentDiv);
+		document.body.appendChild(modal);
+	}
+	
 	async parseActiveMarkdown() {
 		// get properties
 		const prop = this.getArticleProperties();


### PR DESCRIPTION
1.新增图片格式验证工具，自动将非标准格式转换为JPEG以确保平台兼容性。
2.集成链接转粗体标签功能，用于在草稿内保留链接样式。
3.新增HTML内容压缩处理机制。保证发布到草稿时格式正确，修复发布时多出来的换行导致ol下有序号，没内容。
4.还原code.ts的代码，该代码会影响内部样式渲染。相同功能在HTML内容压缩处理内实现。
5.修复脚注token.text为空时显示undefined。
6.优化ollamaCLient的选择判断逻辑，从判断是否是http协议，改为判断是否以/v1结尾
7.移除OpenAI客户端硬编码的max_tokens和temperature参数，max_tokens=100时只会输出几个字符，temperature一般不需要设置，用他们默认参数就行。